### PR TITLE
Update install example to match release files

### DIFF
--- a/src/Page/Install.elm
+++ b/src/Page/Install.elm
@@ -89,9 +89,8 @@ view _ _ _ =
             [ Html.text "Once you have the binary, you'll need to give it permission to execute and place it somewhere in your PATH. Below is an example for Mac OS." ]
         , Html.pre []
             [ multilineHtmlText """
-              unzip gren-macOS.zip
-              chmod +x gren
-              mv gren /usr/local/bin/
+              chmod +x gren_mac
+              mv gren_mac /usr/local/bin/gren
               """
             ]
         , Html.p []


### PR DESCRIPTION
The install instruction example does not match the files available on the release page. No zip file available for the binaries, just source code.
I considered adding a curl command to the latest release but this is the smallest change without adding something new.