### PR TITLE
Homepage slight rewording to disambiguate

### DIFF
--- a/src/Page/Index.elm
+++ b/src/Page/Index.elm
@@ -143,7 +143,7 @@ viewItems items =
             [ Html.h3 []
                 [ Html.text "Compiler as an assistant" ]
             , Html.p []
-                [ Html.text "Since side effects and error handling is represented in Gren's type system, the compiler can catch a lot of errors which are usually only discovered when the program is running in other languages." ]
+                [ Html.text "Since side effects and error handling is represented in Gren's type system, the compiler can catch a lot of errors which, in other languages, are usually only discovered when the program is running." ]
             , Html.p []
                 [ Html.text "In Gren, a lot of time has been invested in how error messages are presented to you, so that the compiler feels more like a helpful assistant." ]
             , Html.pre []


### PR DESCRIPTION
I did a double take when reading "errors which are usually only discovered when the program is running in other languages", and I suspect others might as well, so I offer this rewording which I believe will ensure the sentence is parsed correctly on the first try.

To explain, while the words are concise, the grammar is ambiguous and the sentence structure allows interpreting it as "only when **running in other languages**, these errors are usually discovered" as well as the actual intent, "these errors are usually discovered **when the program is running**". 

Feel free to tweak, thanks for your time